### PR TITLE
Add Auto Author Assign Organization Workflow Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # .github
+
+This repository contains organization-wide GitHub workflow templates and other configuration files for our organization.
+
+## Workflow Templates
+
+### auto-author-assign
+
+Automatically assigns PR and issue authors as assignees
+
+**Usage:**
+To use this template in your repository, navigate to the "Actions" tab, click "New workflow," and select "Auto Author Assign Workflow" from the organization templates. No additional configuration is required for basic functionality, but you can customize the workflow by modifying trigger events or using a custom token by editing the `.github/workflows/auto-author-assign.yml` file after adding it to your repository.
+
+### docapprover
+
+Automatically approves doc PRs, and rejects those that have non-doc changes.
+
+**Usage:**
+To use this template in your repository, navigate to the "Actions" tab, click "New workflow," and select "Doc Approver Workflow" from the organization templates. No additional configuration is required for basic functionality, but you can customize the workflow by modifying trigger events or using a custom token by editing the `.github/workflows/doc-approval.yml` file after adding it to your repository.

--- a/workflow-templates/auto-author-assign.properties.json
+++ b/workflow-templates/auto-author-assign.properties.json
@@ -1,0 +1,6 @@
+{
+  "name": "Auto Author Assign Workflow",
+  "description": "Automatically assigns PR and issue authors as assignees",
+  "iconName": "octicon person",
+  "categories": ["automation"]
+}

--- a/workflow-templates/auto-author-assign.yml
+++ b/workflow-templates/auto-author-assign.yml
@@ -1,0 +1,17 @@
+name: Auto Author Assign
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v2.1.1


### PR DESCRIPTION
# Assign Creators of PRs to their PRs

## Summary
This PR adds an organization-wide workflow template that automatically assigns the author as an assignee when pull requests or issues are opened or reopened. This template can be easily applied to any repository within our organization.

## Features
- Automatically assigns PR authors to their pull requests
- Automatically assigns issue authors to their issues
- Works across all repositories that implement the template
- Zero configuration required for basic functionality
- Uses the stable toshimaru/auto-author-assign@v2.1.1 action

## How to Use
Repository owners can add this workflow by:
1. Going to the "Actions" tab in their repository
2. Selecting "New workflow"
3. Finding and selecting the "Auto Author Assign Workflow" under organization templates

No additional configuration is required for the default behavior.